### PR TITLE
Add waiter names and totals report

### DIFF
--- a/src/screens/StitchDesign/sections/ReportSection/ReportSection.jsx
+++ b/src/screens/StitchDesign/sections/ReportSection/ReportSection.jsx
@@ -1,6 +1,14 @@
 import React from "react";
 import { Button } from "../../../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../../../components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../../../components/ui/table";
 
 export const ReportSection = () => {
   const reportData = {
@@ -19,6 +27,14 @@ export const ReportSection = () => {
       { time: "6:00 PM - 7:00 PM", orders: 12 },
     ],
   };
+
+  const waiterTotals = [
+    { id: "W001", name: "John Smith", cash: 250.5, online: 150.0 },
+    { id: "W002", name: "Sarah Johnson", cash: 180.75, online: 210.25 },
+    { id: "W003", name: "Mike Davis", cash: 320.4, online: 95.6 },
+    { id: "W004", name: "Emma Wilson", cash: 140.0, online: 185.0 },
+    { id: "W005", name: "Alex Brown", cash: 200.0, online: 160.5 },
+  ];
 
   return (
     <div className="max-w-[960px] flex-1 grow flex flex-col items-start">
@@ -122,6 +138,59 @@ export const ReportSection = () => {
                 </div>
               ))}
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Waiter Totals */}
+        <Card className="border border-solid border-[#e2dddd] rounded-xl">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-[#161111] [font-family:'Work_Sans',Helvetica]">
+              Waiter Totals
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-white">
+                  <TableHead className="w-[180px] px-4 py-3 [font-family:'Work_Sans',Helvetica] font-medium text-[#161111] text-sm">
+                    Waiter
+                  </TableHead>
+                  <TableHead className="w-[100px] px-4 py-3 [font-family:'Work_Sans',Helvetica] font-medium text-[#161111] text-sm">
+                    ID
+                  </TableHead>
+                  <TableHead className="w-[160px] px-4 py-3 [font-family:'Work_Sans',Helvetica] font-medium text-[#161111] text-sm">
+                    Cash
+                  </TableHead>
+                  <TableHead className="w-[160px] px-4 py-3 [font-family:'Work_Sans',Helvetica] font-medium text-[#161111] text-sm">
+                    Online
+                  </TableHead>
+                  <TableHead className="w-[160px] px-4 py-3 [font-family:'Work_Sans',Helvetica] font-medium text-[#161111] text-sm">
+                    Total
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {waiterTotals.map((w) => (
+                  <TableRow key={w.id} className="border-t border-[#e5e8ea]">
+                    <TableCell className="px-4 py-2 [font-family:'Work_Sans',Helvetica] text-sm text-[#161111]">
+                      {w.name}
+                    </TableCell>
+                    <TableCell className="px-4 py-2 [font-family:'Work_Sans',Helvetica] text-sm text-[#82686b]">
+                      {w.id}
+                    </TableCell>
+                    <TableCell className="px-4 py-2 [font-family:'Work_Sans',Helvetica] text-sm text-[#82686b]">
+                      ${""}{w.cash.toFixed(2)}
+                    </TableCell>
+                    <TableCell className="px-4 py-2 [font-family:'Work_Sans',Helvetica] text-sm text-[#82686b]">
+                      ${""}{w.online.toFixed(2)}
+                    </TableCell>
+                    <TableCell className="px-4 py-2 [font-family:'Work_Sans',Helvetica] text-sm font-medium text-[#161111]">
+                      ${""}{(w.cash + w.online).toFixed(2)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
           </CardContent>
         </Card>
 

--- a/src/screens/StitchDesign/sections/SidebarSection/SidebarSection.jsx
+++ b/src/screens/StitchDesign/sections/SidebarSection/SidebarSection.jsx
@@ -14,7 +14,8 @@ export const SidebarSection = () => {
   // Initial order data for the table with detailed items
   const initialOrders = [
     {
-      waiterId: "#W12345",
+      waiterId: "W001",
+      waiterName: "John Smith",
       table: "Table 5",
       items: [
         { name: "Cappuccino", quantity: 1, price: "$4.50" },
@@ -23,7 +24,8 @@ export const SidebarSection = () => {
       paymentOption: "Online"
     },
     {
-      waiterId: "#W12346",
+      waiterId: "W002",
+      waiterName: "Sarah Johnson",
       table: "Table 2",
       items: [
         { name: "Espresso", quantity: 2, price: "$3.00" },
@@ -33,7 +35,8 @@ export const SidebarSection = () => {
       paymentOption: "Cash"
     },
     {
-      waiterId: "#W12347",
+      waiterId: "W003",
+      waiterName: "Mike Davis",
       table: "Table 8",
       items: [
         { name: "Americano", quantity: 1, price: "$3.50" }
@@ -41,7 +44,8 @@ export const SidebarSection = () => {
       paymentOption: "Online"
     },
     {
-      waiterId: "#W12348",
+      waiterId: "W004",
+      waiterName: "Emma Wilson",
       table: "Table 3",
       items: [
         { name: "Mocha", quantity: 2, price: "$5.00" },
@@ -52,7 +56,8 @@ export const SidebarSection = () => {
       paymentOption: "Cash"
     },
     {
-      waiterId: "#W12349",
+      waiterId: "W005",
+      waiterName: "Alex Brown",
       table: "Table 1",
       items: [
         { name: "Cappuccino", quantity: 1, price: "$4.50" },
@@ -99,8 +104,8 @@ export const SidebarSection = () => {
             <Table>
               <TableHeader>
                 <TableRow className="bg-white">
-                  <TableHead className="w-[120px] px-4 py-3 [font-family:'Work_Sans',Helvetica] font-medium text-[#161111] text-sm">
-                    Waiter ID
+                  <TableHead className="w-[160px] px-4 py-3 [font-family:'Work_Sans',Helvetica] font-medium text-[#161111] text-sm">
+                    Waiter
                   </TableHead>
                   <TableHead className="w-[100px] px-4 py-3 [font-family:'Work_Sans',Helvetica] font-medium text-[#161111] text-sm">
                     Table
@@ -126,7 +131,7 @@ export const SidebarSection = () => {
                     className="border-t border-[#e5e8ea]"
                   >
                     <TableCell className="px-4 py-3 [font-family:'Work_Sans',Helvetica] font-normal text-[#161111] text-sm align-top">
-                      {order.waiterId}
+                      {order.waiterName}
                     </TableCell>
                     <TableCell className="px-4 py-3 [font-family:'Work_Sans',Helvetica] font-normal text-[#82686b] text-sm align-top">
                       {order.table}


### PR DESCRIPTION
## Summary
- show waiter names instead of IDs in Pending Orders
- add table of waiter totals in the Sales Reports section

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d02ceaa74832f9e3b3e3a48402f2a